### PR TITLE
allow for latest versions of packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["magic link", "authentication", "passwordless"]
 [tool.poetry.dependencies]
 python = "^3.6"
 Django = ">=2.1"
-packaging = ">=20.9,<22.0"
+packaging = ">=20.9,<24.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"


### PR DESCRIPTION
Right now trying to use django-magiclink alongside current versions of libraries like `black` results in an error like:

```
Using python3 (3.12.0)

Updating dependencies
Resolving dependencies... (0.1s)

Because django-magiclink (1.3.0) @ django-magiclink depends on packaging (>=20.9,<22.0)
 and black (23.9.1) depends on packaging (>=22.0), django-magiclink (1.3.0) @ django-magiclink is incompatible with black (23.9.1).
And because no versions of black match >23.9.1,<24.0.0, django-magiclink (1.3.0) @ django-magiclink is incompatible with black (>=23.9.1,<24.0.0).
```

This requirement can be safely relaxed it seems, this will work until a 2024 version is released.
