### PR TITLE
Fix IP anonymization for ipv6 client addresses

### DIFF
--- a/magiclink/helpers.py
+++ b/magiclink/helpers.py
@@ -10,7 +10,7 @@ from django.utils.crypto import get_random_string
 
 from . import settings
 from .models import MagicLink, MagicLinkError
-from .utils import get_client_ip, get_url_path
+from .utils import get_client_ip, get_url_path, anonymize_ip_address
 
 
 def create_magiclink(
@@ -37,7 +37,7 @@ def create_magiclink(
     if settings.REQUIRE_SAME_IP:
         client_ip = get_client_ip(request)
         if client_ip and settings.ANONYMIZE_IP:
-            client_ip = client_ip[:client_ip.rfind('.')+1] + '0'
+            client_ip = anonymize_ip_address(client_ip)
 
     expiry = timezone.now() + timedelta(seconds=settings.AUTH_TIMEOUT)
     magic_link = MagicLink.objects.create(

--- a/magiclink/models.py
+++ b/magiclink/models.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from . import settings
-from .utils import get_client_ip
+from .utils import get_client_ip, anonymize_ip_address
 
 User = get_user_model()
 
@@ -111,7 +111,7 @@ class MagicLink(models.Model):
         if settings.REQUIRE_SAME_IP:
             client_ip = get_client_ip(request)
             if client_ip and settings.ANONYMIZE_IP:
-                client_ip = client_ip[:client_ip.rfind('.')+1] + '0'
+                client_ip = anonymize_ip_address(client_ip)
             if self.ip_address != client_ip:
                 self.disable()
                 raise MagicLinkError('IP address is different from the IP '

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -202,6 +202,20 @@ def test_validate_wrong_ip(user, magic_link):  # NOQA: F811
 
 
 @pytest.mark.django_db
+def test_validate_ipv6_anonymization(user, magic_link):  # NOQA: F811
+    request = HttpRequest()
+    request.META['REMOTE_ADDR'] = '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+
+    ml = magic_link(request)
+    request.COOKIES[f'magiclink{ml.pk}'] = ml.cookie_value
+    ml.ip_address = '2001:db8:85a3::'
+    ml.save()
+
+    ml_user = ml.validate(request=request, email=user.email.upper())
+    assert ml_user == user
+
+
+@pytest.mark.django_db
 def test_validate_different_browser(user, magic_link):  # NOQA: F811
     request = HttpRequest()
     ml = magic_link(request)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from django.http import HttpRequest
 
-from magiclink.utils import get_client_ip, get_url_path
+from magiclink.utils import get_client_ip, get_url_path, anonymize_ip_address
 
 
 def test_get_client_ip_http_x_forwarded_for():
@@ -29,3 +29,19 @@ def test_get_url_path_with_path():
     url_name = '/test/'
     url = get_url_path(url_name)
     assert url == '/test/'
+
+def test_anonymize_ip_address_ipv4():
+    ipv4 = '127.0.0.1'
+    anonymized_ipv4 = anonymize_ip_address(ipv4)
+    assert anonymized_ipv4 == '127.0.0.0' # last octet zeroed
+
+
+def test_anonymize_ip_address_ipv6():
+    ipv6 = '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    anonymized_ipv6 = anonymize_ip_address(ipv6)
+    assert anonymized_ipv6 == '2001:db8:85a3::' # last 80 bits (SLA ID + Interface ID) zeroed
+
+def test_anonymize_ip_address_invalid_value():
+    bad_input = '127'
+    result = anonymize_ip_address(bad_input)
+    assert result == bad_input # returns original input


### PR DESCRIPTION
Hi @pyepye first of all thanks for this great library! Your library made implementing magic links a breeze!

This PR fixes ip anonymization for ipv6 clients.

Before this fix, if a client had an ipv6 address the creation of the
magic link would fail with this error:

```
invalid input syntax for type inet: "0"
```

This is because the original ip anonymization code below assumed the ip was an
ipv4 address. When an ipv6 address was given, the ip address would get
mangled into '0' and subsequently fail the validation of the GenericIPAddressField.

```py
client_ip[:client_ip.rfind('.')+1] + '0'
```

This commit adds support for anonymizing ipv6 addresses. For these addresses
the last 80 bits are zeroed out. This seems to be the recommended practise,
as also used by Google Analytics.